### PR TITLE
Handle rename lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: rust
+rust:
+  - nightly-2018-08-24
+script:
+  - RUSTFLAGS="-D warnings" cargo test --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
 language: rust
-rust:
-  - nightly-2018-08-24
+env:
+  - RUSTFLAGS="-D warnings"
 script:
-  - RUSTFLAGS="-D warnings" cargo test --verbose --all
+  - cargo build --verbose --all
+  - cargo test --verbose --all
+
+matrix:
+  include:
+    - rust: beta
+    - rust: nightly-2018-08-24
+    - rust: nightly-2018-08-24
+      before_script:
+        - rustup component add rustfmt-preview --toolchain nightly
+      script:
+        - cargo +nightly fmt --all -- --check
+    - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,15 @@ env:
 script:
   - cargo build --verbose --all
   - cargo test --verbose --all
+rust:
+  - beta
+  - nightly
+  - stable
 
 matrix:
   include:
-    - rust: beta
-    - rust: nightly-2018-08-24
-    - rust: nightly-2018-08-24
+    - rust: nightly
       before_script:
         - rustup component add rustfmt-preview --toolchain nightly
       script:
         - cargo +nightly fmt --all -- --check
-    - rust: stable

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,10 @@ fn test_path_for_deleted_line() {
     assert_eq!(file_path_for_line(" D foo.txt"), None);
 }
 
-fn paths_for_lines(lines: Vec<&str>) -> Vec<std::path::PathBuf> {
+fn paths_for_lines<'a, I>(lines: I) -> Vec<std::path::PathBuf>
+where
+    I: Iterator<Item = &'a str>,
+{
     lines
         .into_iter()
         .filter_map(file_path_for_line)
@@ -83,7 +86,7 @@ fn paths_for_lines(lines: Vec<&str>) -> Vec<std::path::PathBuf> {
 
 #[test]
 fn test_getting_paths_from_lines() {
-    let lines = [
+    let lines = vec![
         " M foo.txt",
         " M \"bar baz.txt\"",
         " R qux.txt -> quxx.txt",
@@ -96,7 +99,7 @@ fn test_getting_paths_from_lines() {
             .map(std::path::PathBuf::from)
             .collect();
 
-    assert_eq!(paths_for_lines(lines.to_vec()), expected)
+    assert_eq!(paths_for_lines(lines.into_iter()), expected)
 }
 
 fn main() {
@@ -117,7 +120,7 @@ fn main() {
     let path_from_root = pathdiff::diff_paths(&pwd, &git_dir)
         .expect("Both paths should be absolute");
 
-    for file_path in paths_for_lines(status.lines().collect()) {
+    for file_path in paths_for_lines(status.lines()) {
         let relative_path = pathdiff::diff_paths(&file_path, &path_from_root)
             .expect("File must be in git repo");
         println!("\"{}\"", relative_path.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,22 @@ fn test_path_for_modified_line() {
 }
 
 #[test]
+fn test_path_for_renamed_line() {
+    assert_eq!(
+        file_path_for_line(" R foo.txt -> bar.txt"),
+        Some("bar.txt".to_string())
+    );
+}
+
+#[test]
+fn test_path_for_changed_line() {
+    assert_eq!(
+        file_path_for_line(" C foo.txt -> bar.txt"),
+        Some("bar.txt".to_string())
+    );
+}
+
+#[test]
 fn test_path_for_deleted_line() {
     assert_eq!(file_path_for_line(" D foo.txt"), None);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,12 @@ fn test_simple_rename() {
     assert_eq!(new_file_from_rename("foo.txt -> bar.txt"), "bar.txt");
 }
 
+#[test]
+#[should_panic(expected = "Had file with '->' in the name")]
+fn test_complex_rename() {
+    new_file_from_rename("\"foo -> bar.txt\" -> baz.txt");
+}
+
 fn file_path_for_line(line: &str) -> Option<String> {
     let trimmed = line.trim();
     let idx = trimmed

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,84 @@ fn run_git_command(args: &[&str]) -> Option<String> {
     return Some(String::from(stdout));
 }
 
+fn trim_quotes(string: &str) -> String {
+    string.trim_matches('"').to_string()
+}
+
+#[test]
+fn test_trim_quotes() {
+    assert_eq!(trim_quotes("\"foo bar.txt\""), "foo bar.txt")
+}
+
+#[test]
+fn test_trim_multiple_quotes() {
+    assert_eq!(trim_quotes("\"\"foo bar.txt\""), "foo bar.txt")
+}
+
+fn new_file_from_rename(line: &str) -> String {
+    let files: Vec<&str> = line.split(" -> ").collect();
+    assert!(files.len() == 2, "Had file with '->' in the name");
+    return files.last().unwrap().to_string();
+}
+
+#[test]
+fn test_simple_rename() {
+    assert_eq!(new_file_from_rename("foo.txt -> bar.txt"), "bar.txt");
+}
+
+fn file_path_for_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let idx = trimmed
+        .find(char::is_whitespace)
+        .expect("No space in line, unexpected output from git status");
+    let (file_status, file) = trimmed.split_at(idx);
+
+    match file_status {
+        "D" => None,
+        "R" | "C" => Some(new_file_from_rename(&file.trim())),
+        _ => Some(file.trim().to_string()),
+    }.map(|x| trim_quotes(&x))
+}
+
+#[test]
+fn test_path_for_modified_line() {
+    assert_eq!(
+        file_path_for_line(" M foo.txt"),
+        Some("foo.txt".to_string())
+    );
+}
+
+#[test]
+fn test_path_for_deleted_line() {
+    assert_eq!(file_path_for_line(" D foo.txt"), None);
+}
+
+fn paths_for_lines(lines: Vec<&str>) -> Vec<std::path::PathBuf> {
+    lines
+        .into_iter()
+        .filter_map(file_path_for_line)
+        .map(std::path::PathBuf::from)
+        .collect()
+}
+
+#[test]
+fn test_getting_paths_from_lines() {
+    let lines = [
+        " M foo.txt",
+        " M \"bar baz.txt\"",
+        " R qux.txt -> quxx.txt",
+        " D deleted.txt",
+    ];
+
+    let expected: Vec<std::path::PathBuf> =
+        ["foo.txt", "bar baz.txt", "quxx.txt"]
+            .iter()
+            .map(std::path::PathBuf::from)
+            .collect();
+
+    assert_eq!(paths_for_lines(lines.to_vec()), expected)
+}
+
 fn main() {
     let git_dir = match run_git_command(&["rev-parse", "--show-toplevel"]) {
         Some(output) => std::path::PathBuf::from(&output),
@@ -39,17 +117,9 @@ fn main() {
     let path_from_root = pathdiff::diff_paths(&pwd, &git_dir)
         .expect("Both paths should be absolute");
 
-    for line in status.lines().map(|x| x.trim()) {
-        let idx = line
-            .find(" ")
-            .expect("No space in line, unexpected output from git status");
-        let (file_status, file) = line.split_at(idx);
-        if file_status != "D" {
-            let file_path = std::path::Path::new(file.trim());
-            let relative_path =
-                pathdiff::diff_paths(file_path, &path_from_root)
-                    .expect("File must be in git repo");
-            println!("{}", relative_path.display());
-        }
+    for file_path in paths_for_lines(status.lines().collect()) {
+        let relative_path = pathdiff::diff_paths(&file_path, &path_from_root)
+            .expect("File must be in git repo");
+        println!("\"{}\"", relative_path.display());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,20 +21,6 @@ fn run_git_command(args: &[&str]) -> Option<String> {
     return Some(String::from(stdout));
 }
 
-fn trim_quotes(string: &str) -> String {
-    string.trim_matches('"').to_string()
-}
-
-#[test]
-fn test_trim_quotes() {
-    assert_eq!(trim_quotes("\"foo bar.txt\""), "foo bar.txt")
-}
-
-#[test]
-fn test_trim_multiple_quotes() {
-    assert_eq!(trim_quotes("\"\"foo bar.txt\""), "foo bar.txt")
-}
-
 fn new_file_from_rename(line: &str) -> String {
     let files: Vec<&str> = line.split(" -> ").collect();
     assert!(files.len() == 2, "Had file with '->' in the name");
@@ -57,7 +43,7 @@ fn file_path_for_line(line: &str) -> Option<String> {
         "D" => None,
         "R" | "C" => Some(new_file_from_rename(&file.trim())),
         _ => Some(file.trim().to_string()),
-    }.map(|x| trim_quotes(&x))
+    }.map(|x| x.trim_matches('"').to_string())
 }
 
 #[test]


### PR DESCRIPTION
This has a few changes:

- Handle renamed lines, which happens when you stage changes, to only print the new filename. Ex: ` R foo.txt -> bar.txt` will print `bar.txt`. Note files with ` -> ` in their names are not supported and will cause an assertion failure
- Fix quote handling, previously files like ` M "foo bar.txt"` would be incorrectly quoted if they were relative paths, now the quotes are stripped, and quotes are re-added to all files before printing. Note that files with quotes in the names are not supported